### PR TITLE
fix: add required owner field and schema refs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,16 @@
 {
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "itkdev-marketplace",
+  "description": "ITK Dev team tools and MCP servers for Claude Code",
+  "owner": {
+    "name": "ITK Dev",
+    "email": "itkdev@mkb.aarhus.dk"
+  },
   "plugins": [
-    { "name": "itkdev-tools", "source": "." }
+    {
+      "name": "itkdev-tools",
+      "description": "ITK Dev tools and MCP servers for Claude Code",
+      "source": "."
+    }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "itkdev-tools",
   "description": "ITK Dev tools and MCP servers for Claude Code",
   "version": "0.1.0"


### PR DESCRIPTION
## Summary
Fix plugin schema validation errors when running `/plugin marketplace add`.

## Changes
- Add required `owner` object to `marketplace.json`
- Add `$schema` references for validation
- Add `description` to plugin entry in marketplace

## Issue Fixed
```
Error: Invalid schema: owner: Invalid input: expected object, received undefined,
plugins.0.source: Invalid input
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)