### PR TITLE
fix: use valid source path format

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "itkdev-tools",
       "description": "ITK Dev tools and MCP servers for Claude Code",
-      "source": "."
+      "source": "./"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Fix plugin source path validation error.

## Change
Changed `"source": "."` to `"source": "./"` in marketplace.json.

## Issue Fixed
```
Error: Invalid schema: plugins.0.source: Invalid input
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)