### PR TITLE
fix: remove unsupported $schema from plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "itkdev-tools",
   "description": "ITK Dev tools and MCP servers for Claude Code",
   "version": "0.1.0"


### PR DESCRIPTION
## Summary
Remove `$schema` field from plugin.json - it's only valid in marketplace.json.

## Issue Fixed
```
Error: Failed to install: Plugin has an invalid manifest file...
Validation errors: : Unrecognized key: "$schema"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)