### PR TITLE
refactor: rename skills to use itkdev prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ itkdev-claude-plugins/
 ├── commands/                   # Slash commands (Markdown files)
 │   └── example.md
 ├── skills/                     # Skills (Markdown files with frontmatter)
-│   └── itk-dev-github.md
+│   └── itkdev-github-guidelines.md
 └── README.md
 ```
 
@@ -37,7 +37,7 @@ Browser feedback collection tool from [mcp-claude-code-browser-feedback](https:/
 
 ## Included Skills
 
-### itk-dev-github
+### itkdev-github-guidelines
 
 GitHub workflow guidelines for the ITK Dev team. Automatically activates when working with Git, branches, commits, or pull requests. Covers:
 - Branch naming conventions (`feature/issue-{number}-{description}`)

--- a/skills/itkdev-github-guidelines.md
+++ b/skills/itkdev-github-guidelines.md
@@ -1,5 +1,5 @@
 ---
-name: itk-dev-github
+name: itkdev-github-guidelines
 description: GitHub workflow guidelines for itk-dev team. Use when working with Git, creating branches, making commits, opening pull requests, or any GitHub-related development tasks. Ensures compliance with team conventions for branching, commits, changelogs, and PR workflows.
 ---
 

--- a/skills/itkdev-issue-workflow.md
+++ b/skills/itkdev-issue-workflow.md
@@ -1,5 +1,5 @@
 ---
-name: github-issue-workflow
+name: itkdev-issue-workflow
 description: "Autonomous GitHub issue workflow: develop, test, review, merge. Use this skill to work through GitHub issues with minimal user interaction - only pausing when user review/merge is required."
 ---
 


### PR DESCRIPTION
## Summary
Standardizes skill naming to use the `itkdev-` prefix consistently.

- `itk-dev-github` → `itkdev-github-guidelines`
- `github-issue-workflow` → `itkdev-issue-workflow`

## Files Changed
* `skills/itkdev-github-guidelines.md` (renamed from `itk-dev-github.md`) - Updated name in frontmatter
* `skills/itkdev-issue-workflow.md` (renamed from `github-issue-workflow.md`) - Updated name in frontmatter
* `README.md` - Updated references to reflect new skill names

## Test plan
* Verify skill files exist with new names
* Verify frontmatter `name` fields match file names
* Verify README references are updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)