### PR TITLE
feat: add manual release workflow

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,0 +1,154 @@
+name: Manual Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: 'Version bump type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Validate changelog has unreleased content
+        run: |
+          # Extract content between [Unreleased] and next ## [
+          UNRELEASED_CONTENT=$(sed -n '/^## \[Unreleased\]/,/^## \[/p' CHANGELOG.md | sed '1d;$d' | sed '/^$/d')
+
+          if [ -z "$UNRELEASED_CONTENT" ]; then
+            echo "Error: No content in [Unreleased] section. Nothing to release."
+            exit 1
+          fi
+
+          echo "Found unreleased content:"
+          echo "$UNRELEASED_CONTENT"
+
+      - name: Calculate new version
+        id: version
+        env:
+          VERSION_BUMP: ${{ inputs.version_bump }}
+        run: |
+          PLUGIN_JSON=".claude-plugin/plugin.json"
+          CURRENT_VERSION=$(jq -r '.version' "$PLUGIN_JSON")
+
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+
+          case "$VERSION_BUMP" in
+            major)
+              NEW_VERSION="$((MAJOR + 1)).0.0"
+              ;;
+            minor)
+              NEW_VERSION="$MAJOR.$((MINOR + 1)).0"
+              ;;
+            patch)
+              NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
+              ;;
+          esac
+
+          echo "Current version: $CURRENT_VERSION"
+          echo "New version: $NEW_VERSION"
+          echo "current=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          echo "new=$NEW_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Extract release notes from changelog
+        run: |
+          # Extract content between [Unreleased] and next ## [ heading
+          # Remove the first line ([Unreleased]) and last line (next version header)
+          RELEASE_NOTES=$(sed -n '/^## \[Unreleased\]/,/^## \[/p' CHANGELOG.md | sed '1d;$d')
+
+          # Write to file for use in release (handles multiline properly)
+          echo "$RELEASE_NOTES" > release_notes.md
+
+          echo "Release notes extracted:"
+          cat release_notes.md
+
+      - name: Update CHANGELOG.md
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.new }}
+          CURRENT_VERSION: ${{ steps.version.outputs.current }}
+        run: |
+          TODAY=$(date +%Y-%m-%d)
+
+          # Replace [Unreleased] with new version, and add new [Unreleased] section
+          sed -i "s/^## \[Unreleased\]$/## [Unreleased]\n\n## [$NEW_VERSION] - $TODAY/" CHANGELOG.md
+
+          # Update the comparison links at the bottom
+          # Change: [Unreleased]: .../compare/vX.Y.Z...HEAD
+          # To: [Unreleased]: .../compare/vNEW...HEAD
+          sed -i "s|\[Unreleased\]: \(.*\)/compare/v${CURRENT_VERSION}\.\.\.HEAD|[Unreleased]: \1/compare/v${NEW_VERSION}...HEAD|" CHANGELOG.md
+
+          # Add new version link after [Unreleased] link
+          # Find the [Unreleased] link line and add new version link after it
+          sed -i "/^\[Unreleased\]:.*HEAD$/a [$NEW_VERSION]: https://github.com/itk-dev/itkdev-claude-plugins/compare/v${CURRENT_VERSION}...v${NEW_VERSION}" CHANGELOG.md
+
+          echo "Updated CHANGELOG.md:"
+          head -30 CHANGELOG.md
+          echo "..."
+          tail -10 CHANGELOG.md
+
+      - name: Update plugin.json
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.new }}
+        run: |
+          PLUGIN_JSON=".claude-plugin/plugin.json"
+          jq --arg v "$NEW_VERSION" '.version = $v' "$PLUGIN_JSON" > tmp.json && mv tmp.json "$PLUGIN_JSON"
+
+          echo "Updated plugin.json:"
+          cat "$PLUGIN_JSON"
+
+      - name: Commit changes
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.new }}
+        run: |
+          git add CHANGELOG.md .claude-plugin/plugin.json
+          git commit -m "chore: prepare release v${NEW_VERSION}"
+
+      - name: Create and push tag
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.new }}
+        run: |
+          TAG="v${NEW_VERSION}"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin main
+          git push origin "$TAG"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_VERSION: ${{ steps.version.outputs.new }}
+          CURRENT_VERSION: ${{ steps.version.outputs.current }}
+        run: |
+          TAG="v${NEW_VERSION}"
+
+          # Build release notes with header and footer
+          {
+            echo "## What's Changed"
+            echo ""
+            cat release_notes.md
+            echo ""
+            echo "## Full Changelog"
+            echo "https://github.com/itk-dev/itkdev-claude-plugins/compare/v${CURRENT_VERSION}...v${NEW_VERSION}"
+          } > full_release_notes.md
+
+          gh release create "$TAG" \
+            --title "Release $TAG" \
+            --notes-file full_release_notes.md
+
+          echo "Created release: $TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Manual release workflow for creating releases via GitHub Actions UI
+  - Supports patch, minor, and major version bumps
+  - Automatically updates CHANGELOG.md and plugin.json
+  - Creates git tag and GitHub release with notes from changelog
+
 ## [0.3.1] - 2026-01-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -11,13 +11,15 @@ itkdev-claude-plugins/
 │   ├── marketplace.json       # Marketplace catalog
 │   └── mcp-versions.json      # Tracked MCP dependency versions
 ├── .github/workflows/         # GitHub Actions workflows
-│   ├── check-mcp-updates.yml  # Weekly MCP update checker
-│   └── release.yml            # Automated release workflow
+│   ├── check-mcp-updates.yml  # Daily MCP update checker
+│   ├── manual-release.yml     # Manual release workflow
+│   └── release.yml            # MCP dependency release workflow
 ├── .mcp.json                   # MCP server configurations
 ├── commands/                   # Slash commands (Markdown files)
 │   └── example.md
-├── skills/                     # Skills (Markdown files with frontmatter)
-│   └── itkdev-github-guidelines.md
+├── skills/                     # Skills (subdirectories with SKILL.md)
+│   └── itkdev-github-guidelines/
+│       └── SKILL.md
 └── README.md
 ```
 
@@ -49,24 +51,44 @@ GitHub workflow guidelines for the ITK Dev team. Automatically activates when wo
 - Changelog updates (Keep a Changelog format)
 - PR requirements and templates
 
-## Auto-Release Workflow
+## Release Workflows
+
+### Manual Release
+
+Create a new release manually via GitHub Actions:
+
+1. Go to **Actions** > **Manual Release**
+2. Click **Run workflow**
+3. Select version bump type:
+   - `patch` - Bug fixes (0.3.1 → 0.3.2)
+   - `minor` - New features (0.3.1 → 0.4.0)
+   - `major` - Breaking changes (0.3.1 → 1.0.0)
+
+The workflow will:
+- Validate that `[Unreleased]` section has content
+- Update `CHANGELOG.md` with version and date
+- Update `plugin.json` version
+- Create git tag and push
+- Create GitHub release with changelog notes
+
+### MCP Dependency Auto-Release
 
 This plugin automatically releases new versions when MCP server dependencies publish updates.
 
-### How it works
+#### How it works
 
 1. **Daily Check**: A GitHub Actions workflow runs every day at 8:30 UTC
 2. **Version Comparison**: Compares latest MCP releases with tracked versions in `.claude-plugin/mcp-versions.json`
 3. **Automated Release**: If updates are detected, a new patch version is released automatically
 
-### Tracked Dependencies
+#### Tracked Dependencies
 
 | MCP Server | Repository |
 |------------|------------|
 | browser-feedback | [mcp-claude-code-browser-feedback](https://github.com/itk-dev/mcp-claude-code-browser-feedback) |
 | docker | [mcp-itkdev-docker](https://github.com/itk-dev/mcp-itkdev-docker) |
 
-### Manual Trigger
+#### Manual MCP Check
 
 You can manually trigger a dependency check via the GitHub Actions UI:
 1. Go to **Actions** > **Check MCP Updates**
@@ -95,11 +117,17 @@ Create new Markdown files in the `commands/` directory. Each file becomes a slas
 
 ### Adding Skills
 
-Create new Markdown files in the `skills/` directory with YAML frontmatter:
+Create a subdirectory in `skills/` with a `SKILL.md` file containing YAML frontmatter:
+
+```
+skills/
+└── your-skill-name/
+    └── SKILL.md
+```
 
 ```markdown
 ---
-name: skill-name
+name: your-skill-name
 description: When this skill should be activated automatically.
 ---
 


### PR DESCRIPTION
## Summary

Adds a manual release workflow that can be triggered via GitHub Actions UI to create releases without manual file editing.

## Changes

### New Workflow: `.github/workflows/manual-release.yml`

Triggered manually with version bump type selection (patch/minor/major).

**What it does:**
1. Validates `[Unreleased]` section has content
2. Calculates new version based on bump type
3. Extracts release notes from changelog
4. Updates `CHANGELOG.md`:
   - Converts `[Unreleased]` to `[x.y.z] - YYYY-MM-DD`
   - Adds new empty `[Unreleased]` section
   - Updates comparison links
5. Updates `plugin.json` version
6. Commits, tags, and pushes
7. Creates GitHub release with changelog notes

### Documentation Updates

- Updated `README.md` with manual release workflow documentation
- Fixed skills directory structure documentation (subdirectories with `SKILL.md`)
- Added changelog entry

## Test plan

1. Merge this PR
2. Add test content to `[Unreleased]` section
3. Go to **Actions** > **Manual Release** > **Run workflow**
4. Select `patch` bump type
5. Verify:
   - [ ] Version bumped correctly in plugin.json
   - [ ] CHANGELOG.md updated with version and date
   - [ ] New `[Unreleased]` section added
   - [ ] Git tag created
   - [ ] GitHub release created with correct notes

🤖 Generated with [Claude Code](https://claude.ai/code)