### PR TITLE
feat: add project name segment to itkdev-statusline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Project name segment in `itkdev-statusline` showing git repo name (or folder name) for easier session identification
 - `itkdev-statusline` extension with context window usage, git branch, and plan progress display
 
 ### Fixed

--- a/extensions/itkdev-statusline/README.md
+++ b/extensions/itkdev-statusline/README.md
@@ -5,13 +5,14 @@ Claude Code statusline plugin showing git branch, plan progress, and context win
 ## What it shows
 
 ```
-feat/auth │ 2/5 │ ▰▰▰▰▰▱▱▱▱▱ 45%
+itkdev-claude-plugins │ feat/auth │ 2/5 │ ▰▰▰▰▰▱▱▱▱▱ 45%
 ```
 
 | Segment | Source | Notes |
 |---------|--------|-------|
-| Git branch | `.git/HEAD` in `cwd` | Handles detached HEAD (short hash) |
-| Plan progress | `docs/plans/*.md` in `cwd` | Newest non-VERIFIED plan, checkbox counts |
+| Project name | Git remote origin / `workspace.project_dir` / `cwd` basename | Bold. Identifies the session. |
+| Git branch | `.git/HEAD` in project root | Handles detached HEAD (short hash) |
+| Plan progress | `docs/plans/*.md` in project root | Newest non-VERIFIED plan, checkbox counts |
 | Context % | stdin JSON `context_window.remaining_percentage` | 10-segment progress bar, color coded. Falls back to `used_percentage`. |
 
 ### Context color thresholds

--- a/extensions/itkdev-statusline/bin/statusline.sh
+++ b/extensions/itkdev-statusline/bin/statusline.sh
@@ -8,11 +8,13 @@ set -euo pipefail
 # Parse cwd and context percentage from stdin JSON via a single jq call.
 # Prefer remaining_percentage (matches Claude Code's native context display)
 # over used_percentage, which excludes reserved overhead and can differ.
-tsv=$(jq -r '[(.cwd // ""), (if (.context_window.remaining_percentage // null) != null then (100 - .context_window.remaining_percentage) | floor else (.context_window.used_percentage // 0) end), (.transcript_path // "")] | @tsv' 2>/dev/null) || true
+tsv=$(jq -r '[(.cwd // ""), (if (.context_window.remaining_percentage // null) != null then (100 - .context_window.remaining_percentage) | floor else (.context_window.used_percentage // 0) end), (.transcript_path // ""), (.workspace.project_dir // "")] | @tsv' 2>/dev/null) || true
 cwd="${tsv%%$'\t'*}"
 rest="${tsv#*$'\t'}"
 pct="${rest%%$'\t'*}"
-transcript="${rest#*$'\t'}"
+rest2="${rest#*$'\t'}"
+transcript="${rest2%%$'\t'*}"
+project_dir="${rest2#*$'\t'}"
 
 # Bail if we got nothing useful.
 [[ -z "${cwd:-}" ]] && exit 0
@@ -22,8 +24,35 @@ pct="${pct:-0}"
 
 segments=()
 
+# ── Project identifier ───────────────────────────────────────────────
+# Prefer workspace.project_dir over cwd (avoids subdirectory basenames).
+proj_root="${project_dir:-$cwd}"
+project_name=""
+
+# Try git remote origin name first (more meaningful than directory name).
+git_config="${proj_root}/.git/config"
+if [[ -f "$git_config" ]]; then
+  while IFS= read -r line; do
+    case "$line" in
+      *url\ =*)
+        remote_url="${line##*= }"
+        project_name="${remote_url##*/}"
+        project_name="${project_name%.git}"
+        break
+        ;;
+    esac
+  done < "$git_config"
+fi
+
+# Fall back to directory basename.
+: "${project_name:=${proj_root##*/}}"
+
+if [[ -n "$project_name" ]]; then
+  segments+=($'\033[1m'"${project_name}"$'\033[0m')
+fi
+
 # ── Git branch ─────────────────────────────────────────────────────────
-head_file="${cwd}/.git/HEAD"
+head_file="${proj_root}/.git/HEAD"
 if [[ -f "$head_file" ]]; then
   head_content=$(<"$head_file")
   if [[ "$head_content" == ref:\ * ]]; then
@@ -31,7 +60,7 @@ if [[ -f "$head_file" ]]; then
   else
     branch="${head_content:0:7}"  # detached HEAD — short hash
   fi
-  if [[ -z "$(git -C "$cwd" status --porcelain 2>/dev/null)" ]]; then
+  if [[ -z "$(git -C "$proj_root" status --porcelain 2>/dev/null)" ]]; then
     segments+=($'\033[32m'"${branch}"$'\033[0m')   # green = clean
   else
     segments+=($'\033[31m'"${branch}"$'\033[0m')   # red = dirty
@@ -39,7 +68,7 @@ if [[ -f "$head_file" ]]; then
 fi
 
 # ── Plan progress ──────────────────────────────────────────────────────
-plan_dir="${cwd}/docs/plans"
+plan_dir="${proj_root}/docs/plans"
 if [[ -d "$plan_dir" ]]; then
   # Find the newest non-VERIFIED plan file.
   newest_plan=""


### PR DESCRIPTION
## Summary

- Adds a **project name** as the leftmost bold segment in the statusline for easier identification of multiple Claude Code sessions
- Derives name from git remote origin URL (most meaningful), falling back to `workspace.project_dir` or `cwd` basename for non-git projects
- Updates git branch and plan progress sections to use `proj_root` (from `workspace.project_dir`) instead of `cwd`, avoiding incorrect results when navigating subdirectories

**Example output:**
```
itkdev-claude-plugins │ feat/auth │ 2/5 │ ▰▰▰▰▰▱▱▱▱▱ 45%
```

## Test plan

- [ ] Verify project name appears for a git repo with remote origin
- [ ] Verify directory basename is used for non-git directories
- [ ] Verify `workspace.project_dir` takes precedence over `cwd`
- [ ] Restart Claude Code and confirm the segment appears leftmost in the statusline