### PR TITLE
feat: replace itkdev-docker MCP with skills

### DIFF
--- a/.claude-plugin/mcp-versions.json
+++ b/.claude-plugin/mcp-versions.json
@@ -1,4 +1,3 @@
 {
-  "mcp-claude-code-browser-feedback": "v0.4.3",
-  "mcp-itkdev-docker": "v0.1.2"
+  "mcp-claude-code-browser-feedback": "v0.4.3"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "itkdev-tools",
-  "description": "ITK Dev tools and MCP servers for Claude Code",
+  "description": "ITK Dev tools for Claude Code",
   "version": "0.5.0",
   "author": {
     "name": "ITK Dev",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "itkdev-tools",
   "description": "ITK Dev tools and MCP servers for Claude Code",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": {
     "name": "ITK Dev",
     "email": "itkdev@mkb.aarhus.dk"

--- a/.github/workflows/check-mcp-updates.yml
+++ b/.github/workflows/check-mcp-updates.yml
@@ -28,12 +28,7 @@ jobs:
           BROWSER_FEEDBACK_LATEST=$(gh api repos/itk-dev/mcp-claude-code-browser-feedback/releases/latest --jq '.tag_name' 2>/dev/null || echo "none")
           BROWSER_FEEDBACK_TRACKED=$(jq -r '.["mcp-claude-code-browser-feedback"]' "$TRACKED_VERSIONS")
 
-          # Get latest release for mcp-itkdev-docker
-          DOCKER_LATEST=$(gh api repos/itk-dev/mcp-itkdev-docker/releases/latest --jq '.tag_name' 2>/dev/null || echo "none")
-          DOCKER_TRACKED=$(jq -r '.["mcp-itkdev-docker"]' "$TRACKED_VERSIONS")
-
           echo "Browser Feedback: tracked=$BROWSER_FEEDBACK_TRACKED, latest=$BROWSER_FEEDBACK_LATEST"
-          echo "Docker: tracked=$DOCKER_TRACKED, latest=$DOCKER_LATEST"
 
           # Check for updates
           HAS_UPDATES="false"
@@ -44,18 +39,9 @@ jobs:
             SUMMARY="mcp-claude-code-browser-feedback: $BROWSER_FEEDBACK_TRACKED -> $BROWSER_FEEDBACK_LATEST"
           fi
 
-          if [ "$DOCKER_LATEST" != "none" ] && [ "$DOCKER_LATEST" != "$DOCKER_TRACKED" ]; then
-            HAS_UPDATES="true"
-            if [ -n "$SUMMARY" ]; then
-              SUMMARY="$SUMMARY, "
-            fi
-            SUMMARY="${SUMMARY}mcp-itkdev-docker: $DOCKER_TRACKED -> $DOCKER_LATEST"
-          fi
-
           echo "has_updates=$HAS_UPDATES" >> "$GITHUB_OUTPUT"
           echo "summary=$SUMMARY" >> "$GITHUB_OUTPUT"
           echo "browser_feedback_latest=$BROWSER_FEEDBACK_LATEST" >> "$GITHUB_OUTPUT"
-          echo "docker_latest=$DOCKER_LATEST" >> "$GITHUB_OUTPUT"
 
           echo "Has updates: $HAS_UPDATES"
           echo "Summary: $SUMMARY"
@@ -65,7 +51,6 @@ jobs:
         env:
           SUMMARY: ${{ steps.check.outputs.summary }}
           BROWSER_FEEDBACK_LATEST: ${{ steps.check.outputs.browser_feedback_latest }}
-          DOCKER_LATEST: ${{ steps.check.outputs.docker_latest }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -76,7 +61,6 @@ jobs:
               ref: 'main',
               inputs: {
                 updates_summary: process.env.SUMMARY,
-                browser_feedback_version: process.env.BROWSER_FEEDBACK_LATEST,
-                docker_version: process.env.DOCKER_LATEST
+                browser_feedback_version: process.env.BROWSER_FEEDBACK_LATEST
               }
             })

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,6 @@ on:
         description: 'New version of mcp-claude-code-browser-feedback'
         required: false
         type: string
-      docker_version:
-        description: 'New version of mcp-itkdev-docker'
-        required: false
-        type: string
 
 jobs:
   release:
@@ -36,7 +32,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           UPDATES_SUMMARY: ${{ inputs.updates_summary }}
           BROWSER_FEEDBACK_VERSION: ${{ inputs.browser_feedback_version }}
-          DOCKER_VERSION: ${{ inputs.docker_version }}
         run: |
           set -e
 
@@ -57,10 +52,6 @@ jobs:
           # Update mcp-versions.json with new tracked versions
           if [ -n "$BROWSER_FEEDBACK_VERSION" ] && [ "$BROWSER_FEEDBACK_VERSION" != "none" ]; then
             jq --arg v "$BROWSER_FEEDBACK_VERSION" '.["mcp-claude-code-browser-feedback"] = $v' "$MCP_VERSIONS" > tmp.json && mv tmp.json "$MCP_VERSIONS"
-          fi
-
-          if [ -n "$DOCKER_VERSION" ] && [ "$DOCKER_VERSION" != "none" ]; then
-            jq --arg v "$DOCKER_VERSION" '.["mcp-itkdev-docker"] = $v' "$MCP_VERSIONS" > tmp.json && mv tmp.json "$MCP_VERSIONS"
           fi
 
           # Commit changes
@@ -84,8 +75,7 @@ jobs:
           $UPDATES_SUMMARY
 
           ## MCP Versions
-          - mcp-claude-code-browser-feedback: $(jq -r '.["mcp-claude-code-browser-feedback"]' "$MCP_VERSIONS")
-          - mcp-itkdev-docker: $(jq -r '.["mcp-itkdev-docker"]' "$MCP_VERSIONS")"
+          - mcp-claude-code-browser-feedback: $(jq -r '.["mcp-claude-code-browser-feedback"]' "$MCP_VERSIONS")"
 
           gh release create "$TAG" \
             --title "Release $TAG" \

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,10 +3,6 @@
     "browser-feedback": {
       "command": "npx",
       "args": ["-y", "github:itk-dev/mcp-claude-code-browser-feedback"]
-    },
-    "itkdev-docker": {
-      "command": "npx",
-      "args": ["-y", "github:itk-dev/mcp-itkdev-docker"]
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `itkdev-docker` skill: Docker development environment (CLI reference, Compose architecture, services, Traefik, server deployments, project detection, template comparison)
+- `itkdev-docker-templates` skill: Project template conventions (available templates, installation, setup workflows, procedural template operations)
+- `itkdev-taskfile` skill: Taskfile development workflows (task patterns, coding standards, site management, asset building)
+- `itkdev-gh-actions` skill: GitHub Actions workflow templates (general, Drupal, Symfony workflows, configuration files)
 - Project name segment in `itkdev-statusline` showing git repo name (or folder name) for easier session identification
 - `itkdev-statusline` extension with context window usage, git branch, and plan progress display
+
+### Changed
+
+- Trimmed `itkdev-drupal` skill to remove Docker/Taskfile content now covered by dedicated skills, added cross-references
+- Bumped plugin version to 0.5.0
+
+### Removed
+
+- Removed `itkdev-docker` MCP server from `.mcp.json` (replaced by skills)
+- Removed `mcp-itkdev-docker` entry from `mcp-versions.json`
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,14 @@ itkdev-claude-plugins/
 │   └── itkdev-statusline/
 ├── skills/                     # Skills (subdirectories with SKILL.md)
 │   ├── itkdev-adr/
+│   ├── itkdev-docker/
+│   ├── itkdev-docker-templates/
 │   ├── itkdev-documentation/
 │   ├── itkdev-drupal/
+│   ├── itkdev-gh-actions/
 │   ├── itkdev-github-guidelines/
-│   └── itkdev-issue-workflow/
+│   ├── itkdev-issue-workflow/
+│   └── itkdev-taskfile/
 └── README.md
 ```
 
@@ -47,11 +51,23 @@ Team members can install the marketplace and plugins with:
 
 Browser feedback collection tool from [mcp-claude-code-browser-feedback](https://github.com/itk-dev/mcp-claude-code-browser-feedback).
 
+## Included Skills
+
 ### itkdev-docker
 
-Docker environment management for ITK Dev projects from [mcp-itkdev-docker](https://github.com/itk-dev/mcp-itkdev-docker). Provides template detection, comparison, and setup tools for ITK Dev Docker configurations.
+Docker development environment for ITK Dev projects. Covers the `itkdev-docker-compose` CLI, Docker Compose architecture, service configuration, Traefik reverse proxy, server deployments, project detection, and template comparison.
 
-## Included Skills
+### itkdev-docker-templates
+
+Project template conventions for ITK Dev Docker projects. Covers available templates, installation, setup workflows, and procedural template operations (listing, fetching, comparing).
+
+### itkdev-gh-actions
+
+GitHub Actions workflow templates for ITK Dev projects. Covers general, Drupal, Drupal module, and Symfony workflows, configuration files, and workflow management.
+
+### itkdev-taskfile
+
+Taskfile development workflows for ITK Dev projects. Covers task patterns, coding standards tasks, site management, asset building, and common workflows.
 
 ### itkdev-adr
 
@@ -130,7 +146,6 @@ This plugin automatically releases new versions when MCP server dependencies pub
 | MCP Server | Repository |
 |------------|------------|
 | browser-feedback | [mcp-claude-code-browser-feedback](https://github.com/itk-dev/mcp-claude-code-browser-feedback) |
-| itkdev-docker | [mcp-itkdev-docker](https://github.com/itk-dev/mcp-itkdev-docker) |
 
 #### Manual MCP Check
 

--- a/skills/itkdev-docker-templates/SKILL.md
+++ b/skills/itkdev-docker-templates/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: itkdev-docker-templates
+description: Project template conventions for ITK Dev Docker projects. Use when setting up new projects, installing or updating Docker templates, comparing project config against templates, scaffolding project structure, or asking about available templates.
+---
+
+# ITK Dev Docker Project Templates
+
+You are assisting with ITK Dev Docker project templates from the `devops_itkdev-docker` repository. This skill covers template selection, installation, comparison, and project scaffolding.
+
+## Available Templates
+
+| Template | Framework | PHP Image | Web Root | Memcached | Drush |
+|---|---|---|---|---|---|
+| `drupal-8` | Drupal 8 | itkdev/php8.1-fpm | /app/web | Yes | Yes |
+| `drupal-9` | Drupal 9 | itkdev/php8.1-fpm | /app/web | Yes | Yes |
+| `drupal-10` | Drupal 10 | itkdev/php8.3-fpm | /app/web | Yes | Yes |
+| `drupal-11` | Drupal 11 | itkdev/php8.4-fpm | /app/web | Yes | Yes |
+| `drupal-module` | Drupal module | itkdev/php8.3-fpm | /app/web | Yes | Yes |
+| `symfony-6` | Symfony 6 | itkdev/php8.1-fpm | /app/public | No | No |
+| `symfony-7` | Symfony 7 | itkdev/php8.3-fpm | /app/public | No | No |
+| `symfony-8` | Symfony 8 | itkdev/php8.4-fpm | /app/public | No | No |
+
+Base templates (`drupal`, `symfony`) contain shared configuration that version-specific templates extend via symlinks.
+
+## Template Selection Guide
+
+- **New Drupal site**: Use `drupal-11` (or the version matching your Drupal core)
+- **Drupal contrib module**: Use `drupal-module`
+- **New Symfony app**: Use `symfony-8` (or the version matching your Symfony framework)
+- **Existing project**: Match the template to the framework and version in `composer.json`
+
+## Template File Structure
+
+Each template installs these files into the project:
+
+```
+project/
+├── docker-compose.yml              # Base Docker Compose config
+├── docker-compose.server.yml       # Server/production overrides
+├── docker-compose.dev.yml          # Development overrides (symlinked)
+├── docker-compose.redirect.yml     # SSL redirect config (symlinked)
+├── .docker/
+│   ├── nginx.conf                  # Main Nginx configuration
+│   └── templates/
+│       └── default.conf.template   # Nginx vhost template
+├── .env                            # Environment variables (template)
+├── .github/
+│   └── workflows/                  # CI/CD workflow templates
+├── .markdownlint.jsonc             # Markdown linting rules
+├── .php-cs-fixer.dist.php          # PHP CS Fixer config (Symfony)
+├── .phpcs.xml.dist                 # PHP CodeSniffer config (Drupal)
+├── .twig-cs-fixer.dist.php         # Twig CS Fixer config
+├── .prettierrc.yaml                # Prettier config (Symfony)
+└── Taskfile.yml                    # Task automation
+```
+
+Not all files are present in every template. Drupal uses `.phpcs.xml.dist`, Symfony uses `.php-cs-fixer.dist.php`.
+
+## Installing a Template
+
+```bash
+# List available templates
+itkdev-docker-compose template:install --list
+
+# Install a specific template
+itkdev-docker-compose template:install drupal-11
+
+# Force reinstall (overwrites existing files)
+itkdev-docker-compose template:install drupal-11 --force
+
+# Update an existing template
+itkdev-docker-compose template:update
+itkdev-docker-compose template:update --force
+```
+
+After installation, the `.env` file will contain `ITKDEV_TEMPLATE=<template-name>`.
+
+## Setup Workflows
+
+### New Drupal 11 Project
+
+1. Create project: `composer create-project drupal/recommended-project my-project`
+2. `cd my-project`
+3. Install template: `itkdev-docker-compose template:install drupal-11`
+4. Edit `.env`: set `COMPOSE_PROJECT_NAME` and `COMPOSE_DOMAIN`
+5. Start Traefik: `itkdev-docker-compose traefik:start`
+6. Start containers: `docker compose up -d`
+7. Install Drupal: `itkdev-docker-compose drush site:install --yes`
+8. Open site: `itkdev-docker-compose open`
+
+### New Symfony 8 Project
+
+1. Create project: `composer create-project symfony/skeleton my-project`
+2. `cd my-project`
+3. Install template: `itkdev-docker-compose template:install symfony-8`
+4. Edit `.env`: set `COMPOSE_PROJECT_NAME` and `COMPOSE_DOMAIN`
+5. Start Traefik: `itkdev-docker-compose traefik:start`
+6. Start containers: `docker compose up -d`
+7. Open site: `itkdev-docker-compose open`
+
+### Existing Project
+
+1. Identify framework and version from `composer.json`
+2. Install matching template: `itkdev-docker-compose template:install <template>`
+3. Review and merge generated files with existing configuration
+4. Adjust `.env` variables as needed
+
+## Procedural: List Templates
+
+When the user asks to list available templates, run:
+
+```bash
+gh api repos/itk-dev/devops_itkdev-docker/contents/templates --jq '.[].name'
+```
+
+This returns directory names from the templates folder.
+
+## Procedural: Get Template Files
+
+To list files in a specific template:
+
+```bash
+gh api repos/itk-dev/devops_itkdev-docker/contents/templates/{template} --jq '.[].name'
+```
+
+For nested directories (like `.docker/` or `.github/`), follow up with:
+
+```bash
+gh api repos/itk-dev/devops_itkdev-docker/contents/templates/{template}/{subdir} --jq '.[].name'
+```
+
+## Procedural: Get Template File Content
+
+To read a specific template file:
+
+```bash
+curl -sL "https://raw.githubusercontent.com/itk-dev/devops_itkdev-docker/develop/templates/{template}/{file}"
+```
+
+Or via GitHub CLI:
+
+```bash
+gh api repos/itk-dev/devops_itkdev-docker/contents/templates/{template}/{file} --jq '.content' | base64 -d
+```
+
+## Procedural: Compare Project Against Template
+
+When the user asks to compare their project against a template:
+
+1. **Detect template**: Read `.env` for `ITKDEV_TEMPLATE` value
+2. **List template files**: Fetch file list from GitHub (see above)
+3. **For each key file**, compare local vs template:
+
+   Key files to check:
+   - `docker-compose.yml`
+   - `docker-compose.server.yml`
+   - `.docker/nginx.conf`
+   - `.docker/templates/default.conf.template`
+   - `Taskfile.yml`
+   - `.github/workflows/*`
+   - Config files (`.phpcs.xml.dist`, `.markdownlint.jsonc`, etc.)
+
+4. **Version comparison**: Look for `# itk-version: X.Y.Z` comments in compose files. Compare local version against template version.
+
+5. **Report**:
+   - **Missing files**: Template files not present in project
+   - **Outdated files**: Local `itk-version` is older than template
+   - **Matching files**: Local version matches template
+   - **Recommendations**: Suggest updating outdated files, adding missing files

--- a/skills/itkdev-docker/SKILL.md
+++ b/skills/itkdev-docker/SKILL.md
@@ -205,18 +205,9 @@ When you need to detect an ITK Dev Docker project, read these files:
 4. **Services**: Parse `docker-compose.yml` for service names under `services:` key
 5. **Extras**: Check for `Taskfile.yml`, `.github/workflows/` directory
 
-## Template Comparison (Procedural)
+## Template Comparison
 
-When comparing a project against its template:
-
-1. Read `.env` to find `ITKDEV_TEMPLATE` value
-2. Fetch template files from GitHub: `gh api repos/itk-dev/devops_itkdev-docker/contents/templates/{template}`
-3. For each key file (`docker-compose.yml`, `docker-compose.server.yml`, `.docker/nginx.conf`, `.docker/templates/default.conf.template`):
-   - Read local file
-   - Fetch template version: use raw URL `https://raw.githubusercontent.com/itk-dev/devops_itkdev-docker/develop/templates/{template}/{file}`
-   - Compare `# itk-version:` comments to detect outdated files
-   - Flag missing files
-4. Report: missing files, outdated files (version mismatch), and matching files
+For template comparison procedures, see the **"Procedural: Compare Project Against Template"** section in the `itkdev-docker-templates` skill.
 
 ## Troubleshooting
 

--- a/skills/itkdev-docker/SKILL.md
+++ b/skills/itkdev-docker/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: itkdev-docker
+description: Docker development environment for ITK Dev projects. Use when working with Docker, running containers, debugging Docker issues, setting up local dev, using itkdev-docker-compose commands, Traefik reverse proxy, or server deployments.
+---
+
+# ITK Dev Docker Development Environment
+
+You are assisting with Docker-based development in ITK Dev projects. This skill covers the `itkdev-docker-compose` CLI, Docker Compose architecture, service configuration, and server deployments.
+
+**IMPORTANT:** ITK Dev projects run in Docker containers. Never run PHP, Composer, Drush, or other project commands directly on the host. Always use `itkdev-docker-compose` or Taskfile tasks.
+
+## itkdev-docker-compose CLI Reference
+
+The `itkdev-docker-compose` script wraps Docker Compose and provides project-specific commands. It auto-discovers `docker-compose.yml` by searching parent directories.
+
+### Project Operations
+
+```bash
+itkdev-docker-compose url [service [port]]      # Print project URL
+itkdev-docker-compose open [service [port]]      # Open project in browser
+itkdev-docker-compose shell [service]            # Enter container shell
+itkdev-docker-compose down                       # Stop and remove all containers
+itkdev-docker-compose images:pull                # Pull latest Docker images
+itkdev-docker-compose hosts:insert               # Add domain to /etc/hosts
+itkdev-docker-compose version                    # Show script version
+itkdev-docker-compose completions                # Generate shell completions
+```
+
+### PHP/Composer Commands (run inside phpfpm container)
+
+```bash
+itkdev-docker-compose composer install
+itkdev-docker-compose composer require drupal/module_name
+itkdev-docker-compose php script.php
+itkdev-docker-compose vendor/bin/phpcs           # Any vendor/bin command
+itkdev-docker-compose vendor/bin/phpunit
+```
+
+### Drupal-Specific
+
+```bash
+itkdev-docker-compose drush cr                   # Clear cache
+itkdev-docker-compose drush cex -y               # Export config
+itkdev-docker-compose drush cim -y               # Import config
+itkdev-docker-compose drush updb -y              # Run database updates
+```
+
+Drush is auto-detected (composer vs container binary).
+
+### Database Operations
+
+```bash
+itkdev-docker-compose sync:db                    # Sync database from remote
+itkdev-docker-compose sync:files                 # Sync files from remote
+itkdev-docker-compose sync                       # Sync both db and files
+itkdev-docker-compose sql:cli [args]             # MySQL CLI
+itkdev-docker-compose sql:connect                # Print MySQL connection string
+itkdev-docker-compose sql:open                   # Open in database GUI
+itkdev-docker-compose sql:port                   # Get exposed MySQL port
+itkdev-docker-compose sql:log                    # Enable SQL query logging
+```
+
+### Xdebug
+
+```bash
+itkdev-docker-compose xdebug                     # Enable Xdebug, wait for Ctrl-C
+```
+
+Common `XDEBUG_MODE` values: `off` (default), `debug` (step debugging), `coverage`, `debug,coverage`.
+
+### Mail
+
+```bash
+itkdev-docker-compose mail:url                   # Get Mailpit URL
+itkdev-docker-compose mail:open                  # Open Mailpit in browser
+```
+
+### Traefik Reverse Proxy
+
+```bash
+itkdev-docker-compose traefik:start              # Start Traefik
+itkdev-docker-compose traefik:stop               # Stop Traefik
+itkdev-docker-compose traefik:url                # Get Traefik admin URL
+itkdev-docker-compose traefik:open               # Open admin in browser
+itkdev-docker-compose traefik:pull               # Pull latest Traefik images
+itkdev-docker-compose traefik:logs               # View Traefik logs
+```
+
+Traefik provides reverse proxy routing with wildcard SSL for `*.local.itkdev.dk`. The script warns if Traefik is not running.
+
+### Template Management
+
+```bash
+itkdev-docker-compose template:install [name] [--force] [--list]  # Install template
+itkdev-docker-compose template:update [--force]                    # Update template
+itkdev-docker-compose self:update                                  # Update CLI + devops repo
+```
+
+## Docker Compose Architecture
+
+### File Layering
+
+Projects use multiple Compose files that are chained automatically:
+
+| File | Purpose |
+|---|---|
+| `docker-compose.yml` | Base configuration (services, networks, volumes) |
+| `docker-compose.dev.yml` | Development overrides (ports, debug tools) |
+| `docker-compose.server.yml` | Server/production overrides |
+| `docker-compose.redirect.yml` | SSL redirect configuration |
+| `docker-compose.override.yml` | Local developer overrides (gitignored) |
+
+All versioned compose files contain `# itk-version: X.Y.Z` comments for tracking.
+
+### Standard Services
+
+| Service | Image | Purpose |
+|---|---|---|
+| **phpfpm** | `itkdev/php8.x-fpm` | PHP-FPM application server |
+| **nginx** | `nginxinc/nginx-unprivileged:alpine` | Web server |
+| **mariadb** | `itkdev/mariadb` | Database with healthcheck |
+| **memcached** | `memcached:alpine` | Cache (Drupal projects) |
+| **mail** | `axllent/mailpit` | Mail catcher for development |
+| **markdownlint** | Dev profile | Markdown linting |
+| **prettier** | Dev profile | Code formatting |
+
+### Networks
+
+- **frontend**: External network shared with Traefik for routing
+- **app**: Internal bridge network for inter-service communication
+
+### Key Environment Variables
+
+**phpfpm service:**
+- `PHP_XDEBUG_MODE` - Xdebug mode (off/debug/coverage)
+- `PHP_MAX_EXECUTION_TIME` - PHP execution timeout
+- `PHP_MEMORY_LIMIT` - PHP memory limit
+- `PHP_SENDMAIL_PATH` - msmtp mail integration
+- `DOCKER_HOST_DOMAIN` - Host machine domain for Xdebug
+- `PHP_IDE_CONFIG` - IDE server name for debugging
+- `DRUSH_OPTIONS_URI` - Drush base URL (Drupal)
+- `COMPOSE_USER` - Container user (defaults to `deploy`)
+
+**nginx service:**
+- `NGINX_FPM_SERVICE` - PHP-FPM service name
+- `NGINX_WEB_ROOT` - Document root (`/app/web` for Drupal, `/app/public` for Symfony)
+- `NGINX_PORT` - Listen port
+- `NGINX_MAX_BODY_SIZE` - Upload size limit
+
+**mariadb service:**
+- `MYSQL_ROOT_PASSWORD`, `MYSQL_USER`, `MYSQL_PASSWORD`, `MYSQL_DATABASE`
+
+### Traefik Labels
+
+Nginx service uses Traefik labels for routing:
+- Host routing: `` Host(`${COMPOSE_DOMAIN}`) ``
+- Mailpit routing: `` Host(`mail-${COMPOSE_DOMAIN}`) ``
+- Optional HTTPS redirect and metrics auth (`ITKMetricsAuth@file`)
+
+### Nginx Configuration
+
+Projects include `.docker/nginx.conf` (main config) and `.docker/templates/default.conf.template` (vhost template) for nginx.
+
+## .env Configuration
+
+```bash
+COMPOSE_PROJECT_NAME=myproject            # Required: Docker project name
+COMPOSE_DOMAIN=myproject.docker.localhost # Optional: defaults to {project}.docker.localhost
+COMPOSE_USER=deploy                       # Container user
+ITKDEV_TEMPLATE=drupal-11                 # Template name (auto-set on install)
+
+# Remote sync
+REMOTE_HOST=user@server.example.com
+REMOTE_DB_DUMP_CMD="drush sql:dump"
+REMOTE_PATH=/data/www/project/htdocs
+LOCAL_PATH=./web
+REMOTE_EXCLUDE="css\njs\nstyles"
+SYNC_DB_POST_SCRIPT=./scripts/post-sync.sh
+```
+
+The CLI sources both `.env` and `.env.local` (for local overrides).
+
+## Framework Differences
+
+| Feature | Drupal | Symfony |
+|---|---|---|
+| Web root | `/app/web` | `/app/public` |
+| Memcached | Yes | No |
+| Drush | Yes | No |
+| Prettier config | No | Yes (YAML) |
+
+## Server Deployment
+
+Production uses `docker-compose.server.yml` with the `itkdev-docker-compose-server` CLI variant. Server compose files configure production-appropriate settings (no dev tools, proper resource limits).
+
+## Project Detection (Procedural)
+
+When you need to detect an ITK Dev Docker project, read these files:
+
+1. **`docker-compose.yml`**: Look for `# itk-version:` comment and PHP image version (e.g., `itkdev/php8.4-fpm`)
+2. **`.env`**: Read `ITKDEV_TEMPLATE`, `COMPOSE_PROJECT_NAME`, `COMPOSE_DOMAIN`
+3. **Framework detection**:
+   - Drupal: `web/modules` directory, `*.info.yml` files, `drupal/core` in `composer.json`
+   - Symfony: `config/bundles.php`, `symfony/*` packages in `composer.json`
+4. **Services**: Parse `docker-compose.yml` for service names under `services:` key
+5. **Extras**: Check for `Taskfile.yml`, `.github/workflows/` directory
+
+## Template Comparison (Procedural)
+
+When comparing a project against its template:
+
+1. Read `.env` to find `ITKDEV_TEMPLATE` value
+2. Fetch template files from GitHub: `gh api repos/itk-dev/devops_itkdev-docker/contents/templates/{template}`
+3. For each key file (`docker-compose.yml`, `docker-compose.server.yml`, `.docker/nginx.conf`, `.docker/templates/default.conf.template`):
+   - Read local file
+   - Fetch template version: use raw URL `https://raw.githubusercontent.com/itk-dev/devops_itkdev-docker/develop/templates/{template}/{file}`
+   - Compare `# itk-version:` comments to detect outdated files
+   - Flag missing files
+4. Report: missing files, outdated files (version mismatch), and matching files
+
+## Troubleshooting
+
+- **Traefik not running**: Run `itkdev-docker-compose traefik:start`
+- **Port conflicts**: Check for other services on ports 80/443, or use `docker ps`
+- **Container won't start**: Check `docker compose logs <service>` for errors
+- **Database connection refused**: Ensure mariadb healthcheck passes before phpfpm starts
+- **Xdebug not connecting**: Verify `DOCKER_HOST_DOMAIN` points to host (`host.docker.internal` on macOS)
+- **Wrong path mappings**: IDE path mappings must match Docker volume mounts (typically `/app`)
+- **Performance issues**: Set `XDEBUG_MODE=off` when not debugging

--- a/skills/itkdev-drupal/SKILL.md
+++ b/skills/itkdev-drupal/SKILL.md
@@ -16,139 +16,27 @@ Recognize Drupal projects by:
 - `docker-compose.yml` with ITK Dev Docker setup
 - `Taskfile.yml` with defined tasks
 
-## ITK Dev Docker Environment
+## Docker and Taskfile
 
-**IMPORTANT:** ITK Dev projects run in Docker containers. Never run commands directly on the host - always use `itkdev-docker-compose` or Taskfile tasks.
+**IMPORTANT:** ITK Dev projects run in Docker containers. Never run PHP, Composer, Drush, or other project commands directly on the host.
 
-### itkdev-docker-compose Commands
+For Docker environment details (CLI commands, services, configuration), see the `itkdev-docker` skill.
+For Taskfile automation (coding standards, site management, asset building), see the `itkdev-taskfile` skill.
+For project templates and setup, see the `itkdev-docker-templates` skill.
 
-The `itkdev-docker-compose` CLI wraps docker-compose and provides Drupal-specific commands:
+**Quick reference for Drupal-specific commands:**
 
 ```bash
-# Drush (runs inside phpfpm container)
+# Via itkdev-docker-compose
 itkdev-docker-compose drush cr              # Clear cache
 itkdev-docker-compose drush cex -y          # Export config
 itkdev-docker-compose drush cim -y          # Import config
-itkdev-docker-compose drush updb -y         # Run updates
+itkdev-docker-compose composer install      # Install dependencies
 
-# Composer (runs inside phpfpm container)
-itkdev-docker-compose composer install
-itkdev-docker-compose composer require drupal/module_name
-
-# PHP (runs inside phpfpm container)
-itkdev-docker-compose php script.php
-
-# Database
-itkdev-docker-compose sql:cli               # MySQL CLI
-itkdev-docker-compose sync:db               # Sync database from remote
-itkdev-docker-compose sync:files            # Sync files from remote
-itkdev-docker-compose sync                  # Sync both db and files
-
-# Utilities
-itkdev-docker-compose url                   # Print site URL
-itkdev-docker-compose open                  # Open site in browser
-
-# Any vendor/bin command
-itkdev-docker-compose vendor/bin/phpcs      # Run PHP CodeSniffer
-itkdev-docker-compose vendor/bin/phpunit    # Run PHPUnit
+# Via Taskfile (preferred if available)
+task                                         # List available tasks
+task site-update                             # Update site after code changes
 ```
-
-### Taskfile.yml
-
-Projects typically have a `Taskfile.yml` defining common workflows. **Always check for and use Taskfile tasks first** before running raw commands.
-
-Common task patterns:
-```bash
-task                    # List available tasks
-task dev:setup          # Initial project setup
-task dev:reset          # Reset local environment
-task ci                 # Run CI checks (coding standards, tests)
-task ci:coding-standards
-task ci:phpunit
-task config:export      # Export Drupal configuration
-task config:import      # Import Drupal configuration
-```
-
-**Convention:** If a Taskfile.yml exists, prefer `task <name>` over direct `itkdev-docker-compose` commands, as tasks often chain multiple commands and handle edge cases.
-
-## Xdebug
-
-ITK Dev Docker environments include Xdebug for step debugging PHP code.
-
-### Enabling Xdebug
-
-Xdebug is typically controlled via environment variables in the Docker setup:
-
-```bash
-# Check if Xdebug is enabled
-itkdev-docker-compose php -m | grep xdebug
-
-# Enable Xdebug (if using XDEBUG_MODE environment variable)
-# Add to docker-compose.override.yml or .env file:
-XDEBUG_MODE=debug
-```
-
-Common `XDEBUG_MODE` values:
-- `off` - Disable Xdebug (default for performance)
-- `debug` - Enable step debugging
-- `coverage` - Enable code coverage analysis
-- `debug,coverage` - Enable both
-
-### IDE Configuration
-
-#### VS Code
-
-1. Install the **PHP Debug** extension by Xdebug
-2. Create `.vscode/launch.json`:
-
-```json
-{
-  "version": "0.2.0",
-  "configurations": [
-    {
-      "name": "Listen for Xdebug",
-      "type": "php",
-      "request": "launch",
-      "port": 9003,
-      "pathMappings": {
-        "/app": "${workspaceFolder}"
-      }
-    }
-  ]
-}
-```
-
-#### PHPStorm
-
-1. Go to **Settings → PHP → Servers**
-2. Add a server with:
-   - Host: Your local Docker URL (e.g., `project.docker.localhost`)
-   - Port: 80
-   - Debugger: Xdebug
-   - Path mappings: `/app` → project root
-3. Go to **Settings → PHP → Debug**
-   - Debug port: 9003
-4. Click **Start Listening for PHP Debug Connections**
-
-### Debugging Workflow
-
-1. Set breakpoints in your IDE
-2. Start listening for debug connections
-3. Trigger the code (via browser, drush, or CLI)
-4. Step through code using IDE controls
-
-### Debugging Drush Commands
-
-```bash
-# Run drush with Xdebug enabled
-XDEBUG_MODE=debug itkdev-docker-compose drush <command>
-```
-
-### Troubleshooting
-
-- **Xdebug not connecting**: Check that `xdebug.client_host` points to your host machine (usually `host.docker.internal`)
-- **Wrong path mappings**: Ensure IDE path mappings match Docker volume mounts (typically `/app`)
-- **Performance issues**: Set `XDEBUG_MODE=off` when not debugging
 
 ## Code Audit
 

--- a/skills/itkdev-drupal/SKILL.md
+++ b/skills/itkdev-drupal/SKILL.md
@@ -24,7 +24,9 @@ For Docker environment details (CLI commands, services, configuration), see the 
 For Taskfile automation (coding standards, site management, asset building), see the `itkdev-taskfile` skill.
 For project templates and setup, see the `itkdev-docker-templates` skill.
 
-**Quick reference for Drupal-specific commands:**
+These skills are loaded automatically when relevant. Below is a quick reference for the most common Drupal-specific commands:
+
+**Quick reference:**
 
 ```bash
 # Via itkdev-docker-compose

--- a/skills/itkdev-gh-actions/SKILL.md
+++ b/skills/itkdev-gh-actions/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: itkdev-gh-actions
+description: GitHub Actions workflow templates for ITK Dev projects. Use when setting up or updating GitHub Actions workflows, CI/CD pipelines, asking about available workflow templates, or configuring coding standards checks in CI.
+---
+
+# ITK Dev GitHub Actions Workflow Templates
+
+You are assisting with GitHub Actions CI/CD for ITK Dev projects. Workflow templates come from the `devops_itkdev-docker` repository and are installed via `itkdev-docker-compose template:install`.
+
+## Workflow Naming Convention
+
+Workflows are named by **concern**, not by tool:
+
+- `php.yaml` (not `phpcs.yaml` or `php-cs-fixer.yaml`)
+- `markdown.yaml` (not `markdownlint.yaml`)
+- `styles.yaml` (not `prettier-css.yaml`)
+
+## Available Workflow Templates
+
+### General Workflows (all projects)
+
+| Workflow | Purpose | Tool |
+|---|---|---|
+| `changelog.yaml` | Validates CHANGELOG.md is updated | Custom check |
+| `composer.yaml` | Validates composer.json, checks normalization | Composer |
+| `markdown.yaml` | Lints Markdown files | markdownlint-cli |
+| `twig.yaml` | Validates Twig templates | twig-cs-fixer |
+| `yaml.yaml` | Validates YAML files | Prettier |
+
+### Drupal Workflows
+
+| Workflow | Purpose | Tool |
+|---|---|---|
+| `drupal/php.yaml` | PHP coding standards | phpcs (drupal/coder) |
+| `drupal/javascript.yaml` | JavaScript formatting | Prettier |
+| `drupal/styles.yaml` | CSS/SCSS formatting | Prettier |
+| `drupal/site.yaml` | Tests site install/update from config | Drush |
+
+### Drupal Module Workflows
+
+| Workflow | Purpose | Tool |
+|---|---|---|
+| `drupal-module/php.yaml` | PHP coding standards for modules | phpcs (drupal/coder) |
+| `drupal-module/javascript.yaml` | JavaScript formatting | Prettier |
+| `drupal-module/styles.yaml` | CSS/SCSS formatting | Prettier |
+
+### Symfony Workflows
+
+| Workflow | Purpose | Tool |
+|---|---|---|
+| `symfony/php.yaml` | PHP coding standards | php-cs-fixer |
+| `symfony/javascript.yaml` | JavaScript formatting | Prettier |
+| `symfony/styles.yaml` | CSS/SCSS formatting | Prettier |
+
+## Workflow Assumptions
+
+All workflows assume:
+
+- A **phpfpm** service is defined in `docker-compose.yml`
+- `COMPOSE_USER` environment variable is set (defaults to `deploy`)
+- The **frontend** Docker network exists (created by Traefik)
+- Required config files are present (`.phpcs.xml.dist`, `.markdownlint.jsonc`, etc.)
+
+## Required Configuration Files
+
+| Workflow | Config File | Framework |
+|---|---|---|
+| PHP (Drupal) | `.phpcs.xml.dist` | Drupal |
+| PHP (Symfony) | `.php-cs-fixer.dist.php` | Symfony |
+| Twig | `.twig-cs-fixer.dist.php` | Both |
+| Markdown | `.markdownlint.jsonc` | Both |
+| YAML (Symfony) | `.prettierrc.yaml` | Symfony |
+
+These config files are installed automatically with `itkdev-docker-compose template:install`.
+
+## How Workflows Are Installed
+
+Templates include `.github/workflows/` directory with pre-configured workflows:
+
+```bash
+# Install template (includes workflows)
+itkdev-docker-compose template:install drupal-11
+
+# Files created in .github/workflows/:
+# - changelog.yaml
+# - composer.yaml
+# - markdown.yaml
+# - twig.yaml
+# - yaml.yaml
+# - drupal/php.yaml
+# - drupal/javascript.yaml
+# - drupal/styles.yaml
+# - drupal/site.yaml
+```
+
+## Updating Workflows
+
+When new workflow versions are released in the `devops_itkdev-docker` repo:
+
+```bash
+# Update all template files including workflows
+itkdev-docker-compose template:update
+
+# Force update (overwrites local changes)
+itkdev-docker-compose template:update --force
+```
+
+To manually check for updates, compare local workflow files against the template:
+
+```bash
+# Fetch latest workflow from template
+curl -sL "https://raw.githubusercontent.com/itk-dev/devops_itkdev-docker/develop/templates/{template}/.github/workflows/{workflow}"
+```
+
+## Workflow Documentation Headers
+
+Each workflow template includes a documentation block:
+
+```yaml
+### Workflow Title
+###
+### Description of what this workflow checks
+###
+### Required config files and dependencies
+```
+
+## Common CI Pipeline
+
+A typical Drupal 11 project has these workflows:
+
+```
+.github/workflows/
+├── changelog.yaml           # PR must update CHANGELOG.md
+├── composer.yaml            # composer.json valid and normalized
+├── markdown.yaml            # Markdown passes linting
+├── twig.yaml                # Twig templates pass linting
+├── yaml.yaml                # YAML files properly formatted
+└── drupal/
+    ├── php.yaml             # PHP passes phpcs with Drupal standards
+    ├── javascript.yaml      # JS/TS files properly formatted
+    ├── styles.yaml          # CSS/SCSS files properly formatted
+    └── site.yaml            # Drupal installs and updates cleanly
+```
+
+## Procedural: List Available Workflow Templates
+
+To list workflow templates for a specific project type:
+
+```bash
+# General workflows
+gh api repos/itk-dev/devops_itkdev-docker/contents/github/workflows --jq '.[].name'
+
+# Framework-specific workflows
+gh api repos/itk-dev/devops_itkdev-docker/contents/github/workflows/drupal --jq '.[].name'
+gh api repos/itk-dev/devops_itkdev-docker/contents/github/workflows/drupal-module --jq '.[].name'
+gh api repos/itk-dev/devops_itkdev-docker/contents/github/workflows/symfony --jq '.[].name'
+```
+
+## Procedural: Get Workflow Content
+
+```bash
+curl -sL "https://raw.githubusercontent.com/itk-dev/devops_itkdev-docker/develop/github/workflows/{workflow}"
+```
+
+Or for framework-specific:
+
+```bash
+curl -sL "https://raw.githubusercontent.com/itk-dev/devops_itkdev-docker/develop/github/workflows/drupal/{workflow}"
+```

--- a/skills/itkdev-taskfile/SKILL.md
+++ b/skills/itkdev-taskfile/SKILL.md
@@ -1,0 +1,380 @@
+---
+name: itkdev-taskfile
+description: Taskfile development workflows for ITK Dev projects. Use when working with Taskfile.yml, running task commands, setting up task automation, coding standards, site management, asset building, or asking about available tasks.
+---
+
+# ITK Dev Taskfile Workflows
+
+You are assisting with Taskfile-based automation in ITK Dev projects. This skill covers Taskfile.yml structure, standard tasks, and development workflows.
+
+**Convention:** Always check for and use Taskfile tasks before running raw `itkdev-docker-compose` commands. Tasks chain multiple commands and handle edge cases.
+
+## Listing Available Tasks
+
+```bash
+task                    # List all available tasks with descriptions
+task --list-all         # List all tasks including those without descriptions
+```
+
+## Taskfile.yml Structure
+
+ITK Dev Taskfiles follow a standard structure with variables and task composition:
+
+```yaml
+version: '3'
+
+vars:
+  DOCKER: itkdev-docker-compose
+  COMPOSER: "{{.DOCKER}} composer"
+  DRUSH: "{{.DOCKER}} drush"
+  PHP: "{{.DOCKER}} php"
+  NPM: docker compose run --rm node npm
+
+tasks:
+  # Tasks defined here...
+```
+
+### Variable Hierarchy
+
+- `vars:` at root level define global defaults
+- Tasks can override with local `vars:`
+- Dynamic variables use `sh:` for runtime evaluation
+- CLI arguments passed via `-- <args>` syntax (e.g., `task drush -- cr`)
+
+## Core Task Patterns
+
+### Docker Compose Wrapper
+
+```yaml
+compose:
+  desc: Run docker compose command
+  cmds:
+    - docker compose {{.CLI_ARGS}}
+```
+
+Usage: `task compose -- up -d`
+
+### Compose Up
+
+```yaml
+compose-up:
+  desc: Start Docker containers
+  cmds:
+    - docker compose up -d
+```
+
+### Site Install (Drupal)
+
+```yaml
+site-install:
+  desc: Install site from scratch
+  cmds:
+    - "{{.COMPOSER}} install"
+    - "{{.DRUSH}} site:install --existing-config --yes"
+    - "{{.DRUSH}} cr"
+```
+
+### Site Update (Drupal)
+
+```yaml
+site-update:
+  desc: Update site after code changes
+  cmds:
+    - "{{.COMPOSER}} install"
+    - "{{.DRUSH}} updb --yes"
+    - "{{.DRUSH}} cim --yes"
+    - "{{.DRUSH}} cr"
+```
+
+## Composer and Drush Wrappers
+
+```yaml
+composer:
+  desc: Run composer command
+  cmds:
+    - "{{.COMPOSER}} {{.CLI_ARGS}}"
+
+drush:
+  desc: Run drush command
+  cmds:
+    - "{{.DRUSH}} {{.CLI_ARGS}}"
+```
+
+Usage: `task composer -- require drupal/admin_toolbar` or `task drush -- cr`
+
+## Asset Building
+
+```yaml
+npm-install:
+  desc: Install Node.js dependencies
+  cmds:
+    - "{{.NPM}} install"
+
+npm-build:
+  desc: Build frontend assets
+  cmds:
+    - "{{.NPM}} run build"
+
+npm-watch:
+  desc: Watch for frontend asset changes
+  cmds:
+    - "{{.NPM}} run watch"
+```
+
+## Coding Standards Tasks
+
+ITK Dev projects define tasks for checking and auto-fixing coding standards. The pattern follows `coding-standards-{type}:{check|apply}`:
+
+### PHP (Drupal - phpcs/phpcbf)
+
+```yaml
+coding-standards-php-check:
+  desc: Check PHP coding standards
+  cmds:
+    - "{{.DOCKER}} vendor/bin/phpcs"
+
+coding-standards-php-apply:
+  desc: Apply PHP coding standards fixes
+  cmds:
+    - "{{.DOCKER}} vendor/bin/phpcbf"
+```
+
+### PHP (Symfony - php-cs-fixer)
+
+```yaml
+coding-standards-php-check:
+  desc: Check PHP coding standards
+  cmds:
+    - "{{.DOCKER}} vendor/bin/php-cs-fixer fix --dry-run"
+
+coding-standards-php-apply:
+  desc: Apply PHP coding standards fixes
+  cmds:
+    - "{{.DOCKER}} vendor/bin/php-cs-fixer fix"
+```
+
+### JavaScript
+
+```yaml
+coding-standards-javascript-check:
+  desc: Check JavaScript coding standards
+  cmds:
+    - docker compose run --rm prettier --check 'web/**/*.js'
+
+coding-standards-javascript-apply:
+  desc: Apply JavaScript coding standards
+  cmds:
+    - docker compose run --rm prettier --write 'web/**/*.js'
+```
+
+### Markdown
+
+```yaml
+coding-standards-markdown-check:
+  desc: Check Markdown coding standards
+  cmds:
+    - docker compose run --rm markdownlint '**/*.md'
+
+coding-standards-markdown-apply:
+  desc: Apply Markdown coding standards
+  cmds:
+    - docker compose run --rm markdownlint --fix '**/*.md'
+```
+
+### Styles (CSS/SCSS)
+
+```yaml
+coding-standards-styles-check:
+  desc: Check CSS/SCSS coding standards
+  cmds:
+    - docker compose run --rm prettier --check 'web/**/*.scss'
+
+coding-standards-styles-apply:
+  desc: Apply CSS/SCSS coding standards
+  cmds:
+    - docker compose run --rm prettier --write 'web/**/*.scss'
+```
+
+### Twig
+
+```yaml
+coding-standards-twig-check:
+  desc: Check Twig coding standards
+  cmds:
+    - "{{.DOCKER}} vendor/bin/twig-cs-fixer lint"
+
+coding-standards-twig-apply:
+  desc: Apply Twig coding standards
+  cmds:
+    - "{{.DOCKER}} vendor/bin/twig-cs-fixer lint --fix"
+```
+
+### YAML
+
+```yaml
+coding-standards-yaml-check:
+  desc: Check YAML coding standards
+  cmds:
+    - docker compose run --rm prettier --check '**/*.yaml' '**/*.yml'
+
+coding-standards-yaml-apply:
+  desc: Apply YAML coding standards
+  cmds:
+    - docker compose run --rm prettier --write '**/*.yaml' '**/*.yml'
+```
+
+## Code Analysis
+
+```yaml
+code-analysis:
+  desc: Run PHPStan static analysis
+  cmds:
+    - "{{.DOCKER}} vendor/bin/phpstan"
+```
+
+## Database Operations
+
+```yaml
+database-dump:
+  desc: Dump database to file
+  cmds:
+    - "{{.DRUSH}} sql:dump --result-file=/app/dump.sql"
+```
+
+## Development Settings (Drupal)
+
+```yaml
+dev-settings-twig-debug:
+  desc: Enable Twig debug mode
+  cmds:
+    - "{{.DRUSH}} state:set twig_debug true"
+    - "{{.DRUSH}} cr"
+
+dev-settings-markup-cache:
+  desc: Disable render cache for development
+  cmds:
+    - "{{.DRUSH}} state:set system.performance css.preprocess 0"
+    - "{{.DRUSH}} state:set system.performance js.preprocess 0"
+    - "{{.DRUSH}} cr"
+```
+
+## Translation Tasks
+
+```yaml
+translations-import:
+  desc: Import translations
+  cmds:
+    - "{{.DRUSH}} locale:import da /app/translations/da.po"
+    - "{{.DRUSH}} cr"
+
+translations-export:
+  desc: Export translations
+  cmds:
+    - "{{.DRUSH}} locale:export da > /app/translations/da.po"
+```
+
+## Docker Image Management
+
+```yaml
+images-pull:
+  desc: Pull latest Docker images
+  cmds:
+    - docker compose pull
+```
+
+## Fixtures
+
+```yaml
+fixtures-load:
+  desc: Load fixture content
+  cmds:
+    - "{{.DRUSH}} content-fixtures:load --yes"
+    - "{{.DRUSH}} cr"
+```
+
+## Task Patterns
+
+### Prompts (interactive confirmation)
+
+```yaml
+dangerous-task:
+  prompt: This will delete all data. Continue?
+  cmds:
+    - "{{.DRUSH}} sql:drop --yes"
+```
+
+### Silent (suppress command output)
+
+```yaml
+quiet-task:
+  silent: true
+  cmds:
+    - echo "Only this output is shown"
+```
+
+### Dynamic Variables
+
+```yaml
+dynamic-task:
+  vars:
+    BRANCH:
+      sh: git rev-parse --abbrev-ref HEAD
+  cmds:
+    - echo "Current branch: {{.BRANCH}}"
+```
+
+### CLI Arguments
+
+```yaml
+pass-through:
+  cmds:
+    - "{{.DRUSH}} {{.CLI_ARGS}}"
+```
+
+Usage: `task pass-through -- status`
+
+### Task Composition (deps and cmds)
+
+```yaml
+full-setup:
+  deps:
+    - npm-install
+  cmds:
+    - task: site-install
+    - task: npm-build
+```
+
+## Common Workflows
+
+### New Developer Setup
+
+```bash
+task compose-up          # Start containers
+task site-install        # Install site (or site-update for existing)
+task npm-install         # Install frontend dependencies
+task npm-build           # Build assets
+```
+
+### Daily Development
+
+```bash
+task compose-up          # Ensure containers running
+task site-update         # Pull latest config/database changes
+task npm-watch           # Watch for asset changes (if applicable)
+```
+
+### Before Committing
+
+```bash
+task coding-standards-php-check
+task coding-standards-javascript-check
+task coding-standards-twig-check
+task coding-standards-markdown-check
+task code-analysis       # PHPStan (if configured)
+```
+
+Or if a combined CI task exists:
+
+```bash
+task ci                  # Run all checks
+```

--- a/skills/itkdev-taskfile/SKILL.md
+++ b/skills/itkdev-taskfile/SKILL.md
@@ -123,226 +123,56 @@ npm-watch:
 
 ## Coding Standards Tasks
 
-ITK Dev projects define tasks for checking and auto-fixing coding standards. The pattern follows `coding-standards-{type}:{check|apply}`:
+ITK Dev projects define tasks for checking and auto-fixing coding standards. The naming pattern is `coding-standards-{type}-{check|apply}`.
 
-### PHP (Drupal - phpcs/phpcbf)
+**Available types:** `php`, `javascript`, `markdown`, `styles` (CSS/SCSS), `twig`, `yaml`
 
-```yaml
-coding-standards-php-check:
-  desc: Check PHP coding standards
-  cmds:
-    - "{{.DOCKER}} vendor/bin/phpcs"
+Check tasks run linters in read-only mode. Apply tasks auto-fix violations.
 
-coding-standards-php-apply:
-  desc: Apply PHP coding standards fixes
-  cmds:
-    - "{{.DOCKER}} vendor/bin/phpcbf"
+```bash
+# Check all standards
+task coding-standards-php-check
+task coding-standards-javascript-check
+task coding-standards-twig-check
+task coding-standards-markdown-check
+task coding-standards-styles-check
+task coding-standards-yaml-check
+
+# Auto-fix violations
+task coding-standards-php-apply
+task coding-standards-javascript-apply
+task coding-standards-twig-apply
+task coding-standards-markdown-apply
+task coding-standards-styles-apply
+task coding-standards-yaml-apply
 ```
 
-### PHP (Symfony - php-cs-fixer)
+**Tools by framework:**
+- PHP: `phpcs`/`phpcbf` (Drupal) or `php-cs-fixer` (Symfony)
+- JavaScript/Styles/YAML: `prettier`
+- Markdown: `markdownlint`
+- Twig: `twig-cs-fixer`
 
-```yaml
-coding-standards-php-check:
-  desc: Check PHP coding standards
-  cmds:
-    - "{{.DOCKER}} vendor/bin/php-cs-fixer fix --dry-run"
+## Other Common Tasks
 
-coding-standards-php-apply:
-  desc: Apply PHP coding standards fixes
-  cmds:
-    - "{{.DOCKER}} vendor/bin/php-cs-fixer fix"
-```
-
-### JavaScript
-
-```yaml
-coding-standards-javascript-check:
-  desc: Check JavaScript coding standards
-  cmds:
-    - docker compose run --rm prettier --check 'web/**/*.js'
-
-coding-standards-javascript-apply:
-  desc: Apply JavaScript coding standards
-  cmds:
-    - docker compose run --rm prettier --write 'web/**/*.js'
-```
-
-### Markdown
-
-```yaml
-coding-standards-markdown-check:
-  desc: Check Markdown coding standards
-  cmds:
-    - docker compose run --rm markdownlint '**/*.md'
-
-coding-standards-markdown-apply:
-  desc: Apply Markdown coding standards
-  cmds:
-    - docker compose run --rm markdownlint --fix '**/*.md'
-```
-
-### Styles (CSS/SCSS)
-
-```yaml
-coding-standards-styles-check:
-  desc: Check CSS/SCSS coding standards
-  cmds:
-    - docker compose run --rm prettier --check 'web/**/*.scss'
-
-coding-standards-styles-apply:
-  desc: Apply CSS/SCSS coding standards
-  cmds:
-    - docker compose run --rm prettier --write 'web/**/*.scss'
-```
-
-### Twig
-
-```yaml
-coding-standards-twig-check:
-  desc: Check Twig coding standards
-  cmds:
-    - "{{.DOCKER}} vendor/bin/twig-cs-fixer lint"
-
-coding-standards-twig-apply:
-  desc: Apply Twig coding standards
-  cmds:
-    - "{{.DOCKER}} vendor/bin/twig-cs-fixer lint --fix"
-```
-
-### YAML
-
-```yaml
-coding-standards-yaml-check:
-  desc: Check YAML coding standards
-  cmds:
-    - docker compose run --rm prettier --check '**/*.yaml' '**/*.yml'
-
-coding-standards-yaml-apply:
-  desc: Apply YAML coding standards
-  cmds:
-    - docker compose run --rm prettier --write '**/*.yaml' '**/*.yml'
-```
-
-## Code Analysis
-
-```yaml
-code-analysis:
-  desc: Run PHPStan static analysis
-  cmds:
-    - "{{.DOCKER}} vendor/bin/phpstan"
-```
-
-## Database Operations
-
-```yaml
-database-dump:
-  desc: Dump database to file
-  cmds:
-    - "{{.DRUSH}} sql:dump --result-file=/app/dump.sql"
-```
-
-## Development Settings (Drupal)
-
-```yaml
-dev-settings-twig-debug:
-  desc: Enable Twig debug mode
-  cmds:
-    - "{{.DRUSH}} state:set twig_debug true"
-    - "{{.DRUSH}} cr"
-
-dev-settings-markup-cache:
-  desc: Disable render cache for development
-  cmds:
-    - "{{.DRUSH}} state:set system.performance css.preprocess 0"
-    - "{{.DRUSH}} state:set system.performance js.preprocess 0"
-    - "{{.DRUSH}} cr"
-```
-
-## Translation Tasks
-
-```yaml
-translations-import:
-  desc: Import translations
-  cmds:
-    - "{{.DRUSH}} locale:import da /app/translations/da.po"
-    - "{{.DRUSH}} cr"
-
-translations-export:
-  desc: Export translations
-  cmds:
-    - "{{.DRUSH}} locale:export da > /app/translations/da.po"
-```
-
-## Docker Image Management
-
-```yaml
-images-pull:
-  desc: Pull latest Docker images
-  cmds:
-    - docker compose pull
-```
-
-## Fixtures
-
-```yaml
-fixtures-load:
-  desc: Load fixture content
-  cmds:
-    - "{{.DRUSH}} content-fixtures:load --yes"
-    - "{{.DRUSH}} cr"
-```
+| Task | Description |
+|---|---|
+| `code-analysis` | Run PHPStan static analysis |
+| `database-dump` | Dump database to file |
+| `dev-settings-twig-debug` | Enable Twig debug mode |
+| `translations-import` / `translations-export` | Import/export translations |
+| `images-pull` | Pull latest Docker images |
+| `fixtures-load` | Load fixture content |
 
 ## Task Patterns
 
-### Prompts (interactive confirmation)
+Tasks support these Taskfile features:
 
-```yaml
-dangerous-task:
-  prompt: This will delete all data. Continue?
-  cmds:
-    - "{{.DRUSH}} sql:drop --yes"
-```
-
-### Silent (suppress command output)
-
-```yaml
-quiet-task:
-  silent: true
-  cmds:
-    - echo "Only this output is shown"
-```
-
-### Dynamic Variables
-
-```yaml
-dynamic-task:
-  vars:
-    BRANCH:
-      sh: git rev-parse --abbrev-ref HEAD
-  cmds:
-    - echo "Current branch: {{.BRANCH}}"
-```
-
-### CLI Arguments
-
-```yaml
-pass-through:
-  cmds:
-    - "{{.DRUSH}} {{.CLI_ARGS}}"
-```
-
-Usage: `task pass-through -- status`
-
-### Task Composition (deps and cmds)
-
-```yaml
-full-setup:
-  deps:
-    - npm-install
-  cmds:
-    - task: site-install
-    - task: npm-build
-```
+- **CLI arguments**: `task drush -- cr` (pass `-- <args>` to the underlying command)
+- **Prompts**: `prompt:` key for interactive confirmation on dangerous tasks
+- **Silent mode**: `silent: true` suppresses command echo
+- **Dynamic variables**: `sh:` for runtime evaluation (e.g., current git branch)
+- **Composition**: `deps:` for parallel prerequisites, `cmds:` with `task:` for sequential subtasks
 
 ## Common Workflows
 

--- a/skills/itkdev-validate-standards/SKILL.md
+++ b/skills/itkdev-validate-standards/SKILL.md
@@ -109,6 +109,7 @@ Core services (required):
 
 Optional services (check if present):
 - [ ] `worker` — only required for projects using background job processing
+- [ ] Other project-specific services
 
 #### Healthchecks
 

--- a/skills/itkdev-validate-standards/SKILL.md
+++ b/skills/itkdev-validate-standards/SKILL.md
@@ -5,7 +5,7 @@ description: |
   itk-dev/devops_itkdev-docker. Use when: (1) auditing Docker setup, (2)
   "check itk-dev standards", (3) reviewing PR for convention compliance,
   (4) setting up a new itk-dev project, (5) upgrading Docker configuration.
-  Walks through 9 validation areas: MCP tool comparison, docker-compose,
+  Walks through 9 validation areas: template comparison, docker-compose,
   server compose, environment, Taskfile, framework-specific config, Composer,
   GitHub Actions, and miscellaneous files.
 author: Claude Code
@@ -33,43 +33,37 @@ Use this skill when:
 
 ## Solution
 
-### Step 0 — MCP Tool Automated Comparison
+### Step 0 — Automated Comparison
 
-Before manual checks, attempt automated comparison using the
-`plugin:itkdev-tools:itkdev-docker` MCP tools. These provide
-file-level diffs against the canonical template.
+Before manual checks, attempt automated comparison against the canonical
+template. See the `itkdev-docker` and `itkdev-docker-templates` skills
+for full procedural details.
 
 **Procedure:**
 
-1. **Detect project type:**
-   ```
-   Tool: mcp__plugin_itkdev-tools_itkdev-docker__itkdev_detect_project
-   Parameter: path = <project root>
-   ```
-   Returns: template name (e.g., `symfony-7`), PHP version, framework.
+1. **Detect project type:** Read `.env` for `ITKDEV_TEMPLATE` value and
+   `docker-compose.yml` for `# itk-version:` comment and PHP image version.
+   See the `itkdev-docker` skill (Project Detection section).
 
-2. **Compare against template:**
-   ```
-   Tool: mcp__plugin_itkdev-tools_itkdev-docker__itkdev_compare_project
-   Parameter: path = <project root>
-   ```
-   Returns: list of missing, outdated, and extra files vs. the template.
+2. **Compare against template:** Fetch template files from GitHub and compare
+   `# itk-version:` comments in local files against the template versions.
+   See the `itkdev-docker-templates` skill (Compare Project Against Template section).
 
-3. **Fetch canonical file content (for any diffs):**
-   ```
-   Tool: mcp__plugin_itkdev-tools_itkdev-docker__itkdev_get_template_content
-   Parameters: template = <detected template>, file = <relative path>
-   ```
-   Returns: the template's version of the file for manual comparison.
+   ```bash
+   # List template files
+   gh api repos/itk-dev/devops_itkdev-docker/contents/templates/{template} --jq '.[].name'
 
-4. **List available templates (if detection fails):**
+   # Fetch a specific template file for comparison
+   gh api repos/itk-dev/devops_itkdev-docker/contents/templates/{template}/{file} --jq '.content' | base64 -d
    ```
-   Tool: mcp__plugin_itkdev-tools_itkdev-docker__itkdev_list_templates
-   ```
-   Returns: all available templates with PHP versions.
 
-**Fallback:** If MCP tools are unavailable or the project is not detected,
-proceed with the manual checklist below.
+3. **List available templates (if detection fails):**
+   ```bash
+   gh api repos/itk-dev/devops_itkdev-docker/contents/templates --jq '.[].name'
+   ```
+
+**Fallback:** If the project type cannot be detected, proceed with the
+manual checklist below.
 
 #### Project Type Classification
 
@@ -92,7 +86,8 @@ When a check fails but the deviation is documented, report it as
 
 ### Step 1 — Docker Compose (`docker-compose.yml`)
 
-Validate the development Docker Compose file.
+Validate the development Docker Compose file. See the `itkdev-docker` skill
+for full architecture details.
 
 #### Networks
 
@@ -114,7 +109,6 @@ Core services (required):
 
 Optional services (check if present):
 - [ ] `worker` — only required for projects using background job processing
-- [ ] Other project-specific services
 
 #### Healthchecks
 
@@ -141,11 +135,9 @@ Optional services (check if present):
 
 - [ ] `node`, `markdownlint`, `prettier` services have `profiles: [dev]`
 
-> **Note:** Dev profile services (`node`, `markdownlint`, `prettier`) are
-> typically defined in `docker-compose.override.yml` for local customization.
+> **Note:** Dev profile services are typically defined in
+> `docker-compose.override.yml` for local customization.
 > If they only appear in the override file, the check passes automatically.
-> `docker-compose.override.yml` is used for local development customization
-> and is not subject to the same strict validation.
 
 #### Remediation
 
@@ -212,7 +204,8 @@ Validate environment file conventions.
 
 ### Step 4 — Taskfile.yml
 
-Validate task runner configuration.
+Validate task runner configuration. See the `itkdev-taskfile` skill for
+standard patterns and task definitions.
 
 #### Header
 
@@ -233,35 +226,19 @@ Conditional variables:
 #### Required Tasks (all project types)
 
 - [ ] `compose`/`up` — start containers
-- [ ] `down` — stop containers (`{{.DOCKER_COMPOSE}} down`)
+- [ ] `down` — stop containers
 - [ ] A dependency install task (e.g., `install`, `composer:install`)
 
-#### Symfony-Specific Tasks (if detected as Symfony)
+#### Framework-Specific Tasks
 
-- [ ] `lint:twig` — Twig CS Fixer lint
-- [ ] `lint:twig:fix` — Twig CS Fixer fix
-- [ ] `analyze` — PHPStan analyse
-
-#### Drupal-Specific Tasks (if detected as Drupal)
-
-- [ ] `drush` — Run Drush commands
-- [ ] Config import/export tasks
+- [ ] If Symfony: `lint:twig`, `lint:twig:fix`, `analyze`
+- [ ] If Drupal: `drush`, config import/export tasks
 
 #### Optional / Recommended Tasks
 
-The following tasks are recommended but not strictly required. Their absence
-should be noted as suggestions, not failures:
-
-- [ ] `setup` — first-time project setup
-- [ ] `restart` — calls down then up
-- [ ] `ci` — run all CI checks
-- [ ] `lint` — run all linters (calls subtasks)
-- [ ] `lint:php` — PHP CS Fixer dry-run
-- [ ] `lint:php:fix` — PHP CS Fixer fix
-- [ ] `lint:composer` — composer validate + normalize dry-run
-- [ ] `lint:markdown` — markdown lint via container
-- [ ] `lint:styles` — Prettier check on CSS/SCSS
-- [ ] `test` — PHPUnit all tests
+Note as suggestions, not failures:
+`setup`, `restart`, `ci`, `lint`, `lint:php`, `lint:php:fix`,
+`lint:composer`, `lint:markdown`, `lint:styles`, `test`
 
 #### Remediation
 
@@ -269,7 +246,7 @@ should be noted as suggestions, not failures:
 |-------|-----|
 | Missing dotenv | Add `dotenv: [".env.local", ".env"]` |
 | Wrong var names | Rename to match standard: `DOCKER_COMPOSE`, `PHP`, etc. |
-| Missing required task | Add task following the patterns in the template |
+| Missing required task | Add task following the patterns in the `itkdev-taskfile` skill |
 
 ---
 
@@ -347,7 +324,8 @@ Validate Composer configuration.
 
 ### Step 7 — GitHub Actions
 
-Validate CI workflow files.
+Validate CI workflow files. See the `itkdev-gh-actions` skill for available
+workflow templates and naming conventions.
 
 #### Expected Workflow Files
 
@@ -380,7 +358,7 @@ Projects with JS/CSS assets:
 
 | Check | Fix |
 |-------|-----|
-| Missing workflow | Copy from template repo's `github/workflows/symfony/` |
+| Missing workflow | Fetch from template repo (see `itkdev-gh-actions` skill) |
 | Outdated checkout | Update to `actions/checkout@v5` |
 | Missing `COMPOSE_USER` | Add `env: COMPOSE_USER: runner` at workflow level |
 | Missing network create | Add step: `docker network create frontend` |
@@ -424,7 +402,7 @@ Date: <current date>
 
 | Area                     | Status | Issues |
 |--------------------------|--------|--------|
-| Step 0: MCP Comparison   |   /    |   -    |
+| Step 0: Template Compare |   /    |   -    |
 | Step 1: docker-compose   |   /    |   0    |
 | Step 2: Server compose   |   /    |   0    |
 | Step 3: Environment      |   /    |   0    |
@@ -500,7 +478,7 @@ Date: 2026-02-26
 
 | Area                     | Status | Issues |
 |--------------------------|--------|--------|
-| Step 0: MCP Comparison   | PASS   |   0    |
+| Step 0: Template Compare | PASS   |   0    |
 | Step 1: docker-compose   | PASS   |   0    |
 | Step 2: Server compose   | PASS   |   0    |
 | Step 3: Environment      | PASS   |   0    |
@@ -518,11 +496,10 @@ All checks passed. COMPLIANT
 ## References
 
 - Template repository: <https://github.com/itk-dev/devops_itkdev-docker>
-- MCP plugin: `plugin:itkdev-tools:itkdev-docker` (5 tools)
-  - `itkdev_detect_project` — detect project type and PHP version
-  - `itkdev_compare_project` — file-level diff against template
-  - `itkdev_get_template_content` — fetch canonical file from template
-  - `itkdev_get_template_files` — list files in a template
-  - `itkdev_list_templates` — list all available templates
+- Related skills:
+  - `itkdev-docker` — CLI reference, Compose architecture, project detection
+  - `itkdev-docker-templates` — template management, comparison procedures
+  - `itkdev-taskfile` — task patterns, coding standards, workflows
+  - `itkdev-gh-actions` — workflow templates, naming conventions
 - Project CLAUDE.md: conventions and architecture overview
 - Taskfile.dev documentation: <https://taskfile.dev>


### PR DESCRIPTION
## Summary

- Replaces the `itkdev-docker` MCP server (Node.js process dependency) with 4 static skills that provide the same documentation and procedural instructions for tool operations
- Trims overlapping Docker/Taskfile content from `itkdev-drupal` skill, adds cross-references to new skills
- Removes all MCP references from workflows, README, and config files
- Bumps plugin version to 0.5.0

### New skills

| Skill | Purpose |
|---|---|
| `itkdev-docker` | CLI reference, Docker Compose architecture, services, Traefik, server deployments, project detection & template comparison procedures |
| `itkdev-docker-templates` | Available templates, installation, setup workflows, procedural GitHub API operations |
| `itkdev-taskfile` | Task patterns, coding standards (check/apply), site management, asset building, common workflows |
| `itkdev-gh-actions` | Workflow templates (general/Drupal/Symfony), naming conventions, config files, management |

### Files changed

- **4 new** skill files created
- **8 existing** files modified (.mcp.json, plugin.json, mcp-versions.json, CHANGELOG.md, README.md, itkdev-drupal SKILL.md, release.yml, check-mcp-updates.yml)

## Test plan

- [ ] Verify each skill triggers correctly by asking Docker/template/Taskfile/GH Actions questions
- [ ] Test template listing by asking Claude to list available templates (should use `gh api` procedure)
- [ ] Test project detection by asking Claude to detect project type (should read docker-compose.yml and .env)
- [ ] Confirm no MCP server startup errors (itkdev-docker MCP removed from .mcp.json)
- [ ] Verify `itkdev-drupal` skill still works for Drupal-specific questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)