### PR TITLE
feat: split itkdev-skills into three category plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,11 +8,30 @@
   },
   "plugins": [
     {
-      "name": "itkdev-skills",
-      "description": "ITK Dev team conventions, workflows, and coding standards",
+      "name": "itkdev-code-quality-and-review",
+      "description": "ITK Dev code review agent and per-language review skills (PHP, Python, JavaScript), comment review, and standards validation",
       "source": {
-        "source": "github",
-        "repo": "itk-dev/itkdev-skills"
+        "source": "git-subdir",
+        "url": "itk-dev/itkdev-skills",
+        "path": "plugins/itkdev-code-quality-and-review"
+      }
+    },
+    {
+      "name": "itkdev-scaffolding-and-templates",
+      "description": "Docker development environment, project templates, GitHub Actions, Taskfile, and Drupal/Symfony scaffolding",
+      "source": {
+        "source": "git-subdir",
+        "url": "itk-dev/itkdev-skills",
+        "path": "plugins/itkdev-scaffolding-and-templates"
+      }
+    },
+    {
+      "name": "itkdev-business-automation",
+      "description": "Autonomous issue workflow, GitHub guidelines, Architecture Decision Records, and documentation generation",
+      "source": {
+        "source": "git-subdir",
+        "url": "itk-dev/itkdev-skills",
+        "path": "plugins/itkdev-business-automation"
       }
     },
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** Replaced the single `itkdev-skills` plugin entry with three category plugins, all
+  hosted in [itk-dev/itkdev-skills](https://github.com/itk-dev/itkdev-skills) via `git-subdir`
+  sources pointing at `plugins/<name>/`:
+  - `itkdev-code-quality-and-review`
+  - `itkdev-scaffolding-and-templates`
+  - `itkdev-business-automation`
+
+  Existing users must install the new plugins; `itkdev-skills` no longer resolves. Categories follow
+  the skill types in Anthropic's *Lessons from building Claude Code: how we use skills*.
+
 ### Added
 
 - Updated itkdev-skills plugin reference to reflect new `itkdev-symfony` skill and `itkdev-create-project` agent (11 skills, 3 agents)

--- a/README.md
+++ b/README.md
@@ -25,15 +25,16 @@ Team members can install the marketplace and individual plugins:
 /plugin marketplace add itk-dev/itkdev-claude-plugins
 
 # Install plugins individually
-/plugin install itkdev-skills@itkdev-marketplace
+/plugin install itkdev-code-quality-and-review@itkdev-marketplace
+/plugin install itkdev-scaffolding-and-templates@itkdev-marketplace
+/plugin install itkdev-business-automation@itkdev-marketplace
 /plugin install itkdev-browser-feedback@itkdev-marketplace
 /plugin install itkdev-statusline@itkdev-marketplace
 ```
 
-Or install plugins directly from their repos:
+Or install the MCP/statusline plugins directly from their repos:
 
 ```bash
-claude plugin add itk-dev/itkdev-skills
 claude plugin add itk-dev/mcp-claude-code-browser-feedback
 claude plugin add itk-dev/itkdev-claude-code-statusline
 ```
@@ -42,7 +43,9 @@ claude plugin add itk-dev/itkdev-claude-code-statusline
 
 | Plugin | Repository | Description |
 |--------|-----------|-------------|
-| **itkdev-skills** | [itk-dev/itkdev-skills](https://github.com/itk-dev/itkdev-skills) | ITK Dev team conventions, workflows, and coding standards (11 skills, 3 agents) |
+| **itkdev-code-quality-and-review** | [itk-dev/itkdev-skills](https://github.com/itk-dev/itkdev-skills) (`plugins/itkdev-code-quality-and-review`) | Code review agent and per-language review skills (PHP, Python, JavaScript), comment review, standards validation |
+| **itkdev-scaffolding-and-templates** | [itk-dev/itkdev-skills](https://github.com/itk-dev/itkdev-skills) (`plugins/itkdev-scaffolding-and-templates`) | Docker dev environment, project templates, GitHub Actions, Taskfile, Drupal/Symfony scaffolding |
+| **itkdev-business-automation** | [itk-dev/itkdev-skills](https://github.com/itk-dev/itkdev-skills) (`plugins/itkdev-business-automation`) | Autonomous issue workflow, GitHub guidelines, ADRs, documentation generation |
 | **itkdev-browser-feedback** | [itk-dev/mcp-claude-code-browser-feedback](https://github.com/itk-dev/mcp-claude-code-browser-feedback) | Browser-based visual feedback and annotation MCP server |
 | **itkdev-statusline** | [itk-dev/itkdev-claude-code-statusline](https://github.com/itk-dev/itkdev-claude-code-statusline) | Claude Code statusline with git branch, plan/task progress, and context window usage |
 
@@ -91,6 +94,22 @@ To add a new plugin to the marketplace, add an entry to `.claude-plugin/marketpl
   "source": {
     "source": "github",
     "repo": "itk-dev/your-plugin-repo"
+  }
+}
+```
+
+For a plugin that lives in a **subdirectory** of a repo (as the three
+`itkdev-*` plugins do, all hosted in `itk-dev/itkdev-skills`), use a
+`git-subdir` source instead:
+
+```json
+{
+  "name": "your-plugin-name",
+  "description": "Description of your plugin",
+  "source": {
+    "source": "git-subdir",
+    "url": "itk-dev/your-repo",
+    "path": "plugins/your-plugin-name"
   }
 }
 ```


### PR DESCRIPTION
## Summary

Replaces the single `itkdev-skills` plugin entry with **three category plugins**, all hosted in [itk-dev/itkdev-skills](https://github.com/itk-dev/itkdev-skills) via `git-subdir` sources pointing at `plugins/<name>/`:

- `itkdev-code-quality-and-review`
- `itkdev-scaffolding-and-templates`
- `itkdev-business-automation`

Categories follow the skill *types* in Anthropic's [Lessons from building Claude Code: how we use skills](https://claude.com/blog/lessons-from-building-claude-code-how-we-use-skills). `git-subdir` sparse-clones only each subtree.

## Depends on

**[itk-dev/itkdev-skills#5](https://github.com/itk-dev/itkdev-skills/pull/5)** — the restructure that creates the `plugins/<name>/` subtrees. **Merge that PR first**, otherwise these `git-subdir` paths won't resolve.

## ⚠️ Breaking change

`itkdev-skills` no longer resolves as a plugin. Existing users must install the three new plugins (see updated README install commands).

## Test plan

- [x] `jq` parses `marketplace.json`; lists 5 plugins; 3 new `git-subdir` entries with correct `url`/`path`
- [ ] After both PRs merge: `/plugin marketplace update itkdev-marketplace`, then `/plugin install itkdev-code-quality-and-review@itkdev-marketplace` (and the other two) — confirm each installs only its own skills/agents
- [ ] Confirm `itkdev-skills` no longer appears as installable

🤖 Generated with [Claude Code](https://claude.com/claude-code)